### PR TITLE
fix: use gh-token-gen as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ FROM debian:12-slim
 RUN apt-get update && apt-get -y install libssl3 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/gh-token-gen /usr/local/bin/gh-token-gen
 RUN /usr/local/bin/gh-token-gen --help
-CMD ["/usr/local/bin/gh-token-gen"]
+ENTRYPOINT ["/usr/local/bin/gh-token-gen"]
+CMD ["--help"]


### PR DESCRIPTION
address error like below:

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "--gh-out": executable file not found in $PATH: unknown.
```