### PR TITLE
chore: set `GH_TOKEN`

### DIFF
--- a/.github/workflows/release--publish.yaml
+++ b/.github/workflows/release--publish.yaml
@@ -86,3 +86,5 @@ jobs:
           gh release create "v${{ needs.get-version.outputs.full }}" \
             --title "v${{ needs.get-version.outputs.full }}" \
             --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Address error like this:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```