### PR TITLE
fix: remove expires-in input parameter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,6 @@ jobs:
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
-          INPUT_EXPIRE-IN: "180"
       - run: cargo --locked fmt
       - uses: int128/update-generated-files-action@v2
         with:

--- a/action.yaml
+++ b/action.yaml
@@ -7,10 +7,6 @@ inputs:
   private-key:
     description: The application's PEM-encoded private key
     required: true
-  expire-in:
-    description: Set ttl for generated token in specified seconds. Limited to maximum 600 seconds.
-    required: false
-    default: "120"
 outputs:
   token:
     description: Generated token


### PR DESCRIPTION
TTL specified by `expires-in` parameter is just applied to JWT token for authorization.
App installation token expires in 1 hour as fixed so it is no sence.