### PR TITLE
feat: add `endpoint` input parameter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,6 +84,7 @@ jobs:
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
+          INPUT_ENDPOINT: "https://api.github.com"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -98,5 +99,6 @@ jobs:
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
+          INPUT_ENDPOINT: "https://api.github.com"
           # https://github.com/oakcask/wasm-actions/blob/afa65246b280183200c711b64b69c507837b0449/crates/derive/src/codegen.rs#L112
           STATE_WASM_ACTIONS: ${{ steps.generate-token.outputs.wasm_actions }}     

--- a/README.md
+++ b/README.md
@@ -12,10 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: gh-token-gen
-        uses: oakcask/gh-token-gen@v2
+        uses: oakcask/gh-token-gen@v4
         with:
           app-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+```
+
+For GitHub Enterprise Server, set `endpoint` explicitly:
+
+```yaml
+      - id: gh-token-gen
+        uses: oakcask/gh-token-gen@v4
+        with:
+          app-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          endpoint: https://github.example.com/api/v3
 ```
 
 Please check out [action.yaml](./action.yaml) for further explanation of parameters.

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,9 @@ inputs:
   private-key:
     required: true
     description: "The application's PEM-encoded private key"
+  endpoint:
+    default: "https://api.github.com"
+    description: GitHub API endpoint; override this for GHES
 outputs:
   token:
     description: Generated token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,11 @@ struct Input {
         description = "The application's PEM-encoded private key"
     )]
     private_key: String,
-    #[input(env = "GITHUB_API_URL", default = "https://api.github.com")]
+    #[input(
+        name = "endpoint",
+        default = "https://api.github.com",
+        description = "GitHub API endpoint; override this for GHES"
+    )]
     endpoint: String,
     #[input(env = "GITHUB_REPOSITORY")]
     repo: String,


### PR DESCRIPTION
The action trusts `GITHUB_API_URL` from the job environment and sends credentials to whatever host it contains. The value is read from env, then reused to build the installation lookup, token creation, and token deletion. Those requests include the app JWT in Authorization and later the installation token itself.
There is no allowlist for github.com / GHES, so any workflow, wrapper action, or reusable workflow that can influence `GITHUB_API_URL` can exfiltrate both credentials to an attacker-controlled endpoint.

So we decided to remove `GITHUB_API_URL` as input environment variable.

BREAKING CHANGE: no longer accept `GITHUB_API_URL` environment variable use `endpoint` input paraemter instead.