### PR TITLE
feat: add `github-api-url` input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,9 +83,14 @@ jobs:
         run: GITHUB_STATE=${GITHUB_OUTPUT} node index.cjs
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
+          INPUT_CLIENT-ID: ""
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
           INPUT_GITHUB-API-URL: "https://api.github.com"
           INPUT_ENDPOINT: "https://api.github.com"
+          INPUT_OWNER: ""
+          INPUT_REPOSITORIES: ""
+          INPUT_ENTERPRISE: ""
+          INPUT_SKIP-TOKEN-REVOKE: "false"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -99,8 +104,13 @@ jobs:
         if: always() && ${{ steps.generate-token.outputs.wasm_actions != '' }}
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
+          INPUT_CLIENT-ID: ""
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
           INPUT_GITHUB-API-URL: "https://api.github.com"
           INPUT_ENDPOINT: "https://api.github.com"
+          INPUT_OWNER: ""
+          INPUT_REPOSITORIES: ""
+          INPUT_ENTERPRISE: ""
+          INPUT_SKIP-TOKEN-REVOKE: "false"
           # https://github.com/oakcask/wasm-actions/blob/afa65246b280183200c711b64b69c507837b0449/crates/derive/src/codegen.rs#L112
           STATE_WASM_ACTIONS: ${{ steps.generate-token.outputs.wasm_actions }}     

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
-          INPUT_ENDPOINT: "https://api.github.com"
+          INPUT_GITHUB-API-URL: "https://api.github.com"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -99,6 +99,6 @@ jobs:
         env:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
-          INPUT_ENDPOINT: "https://api.github.com"
+          INPUT_GITHUB-API-URL: "https://api.github.com"
           # https://github.com/oakcask/wasm-actions/blob/afa65246b280183200c711b64b69c507837b0449/crates/derive/src/codegen.rs#L112
           STATE_WASM_ACTIONS: ${{ steps.generate-token.outputs.wasm_actions }}     

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,7 @@ jobs:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
           INPUT_GITHUB-API-URL: "https://api.github.com"
+          INPUT_ENDPOINT: "https://api.github.com"
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -100,5 +101,6 @@ jobs:
           INPUT_APP-ID: ${{ secrets.CLIENT_ID }}
           INPUT_PRIVATE-KEY: ${{ secrets.PRIVATE_KEY }}
           INPUT_GITHUB-API-URL: "https://api.github.com"
+          INPUT_ENDPOINT: "https://api.github.com"
           # https://github.com/oakcask/wasm-actions/blob/afa65246b280183200c711b64b69c507837b0449/crates/derive/src/codegen.rs#L112
           STATE_WASM_ACTIONS: ${{ steps.generate-token.outputs.wasm_actions }}     

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 ```
 
-For GitHub Enterprise Server, set `endpoint` explicitly:
+For GitHub Enterprise Server, set `github-api-url` explicitly:
 
 ```yaml
       - id: gh-token-gen
@@ -26,8 +26,10 @@ For GitHub Enterprise Server, set `endpoint` explicitly:
         with:
           app-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-          endpoint: https://github.example.com/api/v3
+          github-api-url: https://github.example.com/api/v3
 ```
+
+The legacy `endpoint` input is still accepted as an alias for `github-api-url`.
 
 Please check out [action.yaml](./action.yaml) for further explanation of parameters.
 To utilize this GitHub Action,

--- a/action.yaml
+++ b/action.yaml
@@ -8,9 +8,12 @@ inputs:
   private-key:
     required: true
     description: "The application's PEM-encoded private key"
-  endpoint:
+  github-api-url:
     default: "https://api.github.com"
-    description: GitHub API endpoint; override this for GHES
+    description: GitHub API URL; override this for GHES
+  endpoint:
+    default: ""
+    description: Deprecated alias for github-api-url
 outputs:
   token:
     description: Generated token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use base64ct::{Base64UrlUnpadded, Encoding};
-use http::Uri;
+use http::{uri::Authority, Uri};
 use log::error;
 mod sign;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ impl Action<Input, Output> for GhTokenGen {
         add_mask(&authorization_header);
 
         let access_token = AccessTokenBuilder {
-            endpoint: Uri::try_from(input.endpoint).map_err(Error::new)?,
+            endpoint: ApiEndpoint::from_inputs(&input.github_api_url, &input.endpoint)?,
             repo: input.repo,
             authorization_header,
             client: reqwest::Client::new(),
@@ -56,7 +56,7 @@ impl Action<Input, Output> for GhTokenGen {
 
     async fn post(input: Input, state: Output) -> Result<(), Error> {
         RemoveAccessTokenRequest {
-            endpoint: Uri::try_from(input.endpoint).map_err(Error::new)?,
+            endpoint: ApiEndpoint::from_inputs(&input.github_api_url, &input.endpoint)?,
             installation_id: state.installation_id,
             token: state.token,
             client: reqwest::Client::new(),
@@ -81,13 +81,71 @@ struct Input {
     )]
     private_key: String,
     #[input(
-        name = "endpoint",
+        name = "github-api-url",
         default = "https://api.github.com",
-        description = "GitHub API endpoint; override this for GHES"
+        description = "GitHub API URL; override this for GHES"
+    )]
+    github_api_url: String,
+    #[input(
+        name = "endpoint",
+        default = "",
+        description = "Deprecated alias for github-api-url"
     )]
     endpoint: String,
     #[input(env = "GITHUB_REPOSITORY")]
     repo: String,
+}
+
+#[derive(Clone)]
+struct ApiEndpoint {
+    scheme: String,
+    authority: Authority,
+    base_path: String,
+}
+
+impl ApiEndpoint {
+    fn from_inputs(github_api_url: &str, endpoint: &str) -> Result<Self, Error> {
+        let value = if endpoint.trim().is_empty() {
+            github_api_url
+        } else {
+            endpoint
+        };
+        Self::parse(value)
+    }
+
+    fn parse(value: &str) -> Result<Self, Error> {
+        let uri = Uri::try_from(value.trim()).map_err(Error::new)?;
+        let scheme = uri
+            .scheme()
+            .ok_or_else(|| Error::from("github-api-url must contain scheme"))?
+            .as_str()
+            .to_string();
+        let authority = uri
+            .authority()
+            .ok_or_else(|| Error::from("github-api-url must contain authority"))?
+            .clone();
+        let base_path = uri
+            .path_and_query()
+            .map(|path| path.path().trim_end_matches('/').to_string())
+            .filter(|path| !path.is_empty() && path != "/")
+            .unwrap_or_default();
+
+        Ok(Self {
+            scheme,
+            authority,
+            base_path,
+        })
+    }
+
+    fn uri(&self, path: &str) -> Result<Uri, Error> {
+        let path = format!("{}{}", self.base_path, path);
+        Uri::builder()
+            .scheme(self.scheme.as_str())
+            .authority(self.authority.as_str())
+            .path_and_query(path)
+            .build()
+            .map_err(Error::new)
+    }
 }
 
 #[derive(ActionOutput, serde::Serialize, serde::Deserialize)]
@@ -123,7 +181,7 @@ impl JwtBuilder {
 }
 
 struct AccessTokenBuilder {
-    endpoint: Uri,
+    endpoint: ApiEndpoint,
     repo: String,
     authorization_header: String,
     client: reqwest::Client,
@@ -153,29 +211,9 @@ struct AccessToken {
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 impl AccessTokenBuilder {
-    fn uri_builder(&self) -> Result<http::uri::Builder, Error> {
-        Ok(Uri::builder()
-            .scheme(
-                self.endpoint
-                    .scheme()
-                    .ok_or_else(|| Error::from("endpoint (GITHUB_API_URL) must contain scheme"))?
-                    .as_str(),
-            )
-            .authority(
-                self.endpoint
-                    .authority()
-                    .ok_or_else(|| Error::from("endpoint (GITHUB_API_URL) must contain authority"))?
-                    .as_str(),
-            ))
-    }
-
     async fn get_installation_id(&self) -> Result<u64, Error> {
         let path = format!("/repos/{}/installation", self.repo);
-        let api = self
-            .uri_builder()?
-            .path_and_query(path)
-            .build()
-            .map_err(Error::new)?;
+        let api = self.endpoint.uri(&path)?;
 
         let res = self
             .client
@@ -201,11 +239,7 @@ impl AccessTokenBuilder {
         let reponame = self.repo.split('/').nth(1).unwrap();
         let installation_id = self.get_installation_id().await?;
         let path = format!("/app/installations/{}/access_tokens", installation_id);
-        let api = self
-            .uri_builder()?
-            .path_and_query(path)
-            .build()
-            .map_err(Error::new)?;
+        let api = self.endpoint.uri(&path)?;
 
         let body = AccessTokenRequest {
             repositories: [reponame],
@@ -237,7 +271,7 @@ impl AccessTokenBuilder {
 }
 
 struct RemoveAccessTokenRequest {
-    endpoint: Uri,
+    endpoint: ApiEndpoint,
     token: String,
     installation_id: u64,
     client: reqwest::Client,
@@ -246,22 +280,7 @@ struct RemoveAccessTokenRequest {
 impl RemoveAccessTokenRequest {
     async fn execute(self) -> Result<(), Error> {
         let path = format!("/app/installations/{}/access_tokens", self.installation_id);
-        let api = Uri::builder()
-            .scheme(
-                self.endpoint
-                    .scheme()
-                    .expect("endpoint (GITHUB_API_URL) must contain scheme")
-                    .as_str(),
-            )
-            .authority(
-                self.endpoint
-                    .authority()
-                    .expect("endpoint (GITHUB_API_URL) must contain authority")
-                    .as_str(),
-            )
-            .path_and_query(path)
-            .build()
-            .map_err(Error::new)?;
+        let api = self.endpoint.uri(&path)?;
 
         let _ = self
             .client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,3 +303,50 @@ fn unix_now() -> i64 {
 fn encode_base64_url(src: &[u8]) -> String {
     Base64UrlUnpadded::encode_string(src)
 }
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn parses_default_github_api_url() {
+        let endpoint = ApiEndpoint::from_inputs("https://api.github.com", "").unwrap();
+
+        assert_eq!(
+            endpoint.uri("/repos/owner/repo/installation").unwrap(),
+            "https://api.github.com/repos/owner/repo/installation"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn preserves_github_enterprise_api_base_path() {
+        let endpoint = ApiEndpoint::from_inputs("https://github.example.com/api/v3/", "").unwrap();
+
+        assert_eq!(
+            endpoint
+                .uri("/app/installations/123/access_tokens")
+                .unwrap(),
+            "https://github.example.com/api/v3/app/installations/123/access_tokens"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn endpoint_alias_overrides_github_api_url() {
+        let endpoint = ApiEndpoint::from_inputs(
+            "https://api.github.com",
+            "https://github.example.com/api/v3",
+        )
+        .unwrap();
+
+        assert_eq!(
+            endpoint.uri("/installation/token").unwrap(),
+            "https://github.example.com/api/v3/installation/token"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn rejects_github_api_url_without_authority() {
+        assert!(ApiEndpoint::from_inputs("https:///api/v3", "").is_err());
+    }
+}


### PR DESCRIPTION
Adds github-api-url compatibility, keeps endpoint as a legacy alias, and preserves GHES API base paths such as /api/v3.