### PR TITLE
feat: expose installation metadata outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Please check out [action.yaml](./action.yaml) for further explanation of paramet
 To utilize this GitHub Action,
 it is required to [setup a GitHub App][setup] and [generate a private key][generate] for the app.
 
+The action outputs `token`, `installation-id`, and `app-slug`.
+
 [setup]: https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps
 [generate]: https://docs.github.com/en/enterprise-cloud@latest/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
 

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,10 @@ inputs:
 outputs:
   token:
     description: Generated token
+  installation-id:
+    description: GitHub App installation ID
+  app-slug:
+    description: GitHub App slug
 runs:
   using: node24
   main: index.cjs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ impl Action<Input, Output> for GhTokenGen {
         add_mask(&access_token.token);
         Ok(Output {
             token: access_token.token,
-            installation_id: access_token.installation_id,
+            installation_id: access_token.installation_id.to_string(),
+            app_slug: access_token.app_slug,
         })
     }
 
@@ -176,7 +177,10 @@ impl ApiEndpoint {
 struct Output {
     #[output(name = "token", description = "Generated token")]
     token: String,
-    installation_id: u64,
+    #[output(name = "installation-id", description = "GitHub App installation ID")]
+    installation_id: String,
+    #[output(name = "app-slug", description = "GitHub App slug")]
+    app_slug: String,
 }
 
 #[derive(Serialize)]
@@ -329,6 +333,7 @@ fn parse_repository(owner: &str, input: &str) -> Result<String, Error> {
 #[derive(Deserialize)]
 struct InstallationResponse {
     id: u64,
+    app_slug: String,
 }
 
 #[derive(Serialize)]
@@ -347,13 +352,14 @@ struct AccessTokenResponse {
 #[derive(Debug, Serialize, Deserialize)]
 struct AccessToken {
     installation_id: u64,
+    app_slug: String,
     token: String,
 }
 
 const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 impl AccessTokenBuilder {
-    async fn get_installation_id(&self) -> Result<u64, Error> {
+    async fn get_installation(&self) -> Result<InstallationResponse, Error> {
         let paths = self.target.installation_paths();
 
         for (index, path) in paths.iter().enumerate() {
@@ -382,14 +388,15 @@ impl AccessTokenBuilder {
             }
 
             let res: InstallationResponse = res.json().await.map_err(Error::new)?;
-            return Ok(res.id);
+            return Ok(res);
         }
 
         Err(Error::from("installation could not be resolved"))
     }
 
     async fn build(self) -> Result<AccessToken, Error> {
-        let installation_id = self.get_installation_id().await?;
+        let installation = self.get_installation().await?;
+        let installation_id = installation.id;
         let path = format!("/app/installations/{}/access_tokens", installation_id);
         let api = self.endpoint.uri(&path)?;
 
@@ -417,6 +424,7 @@ impl AccessTokenBuilder {
             add_mask(&res.token);
             Ok(AccessToken {
                 installation_id,
+                app_slug: installation.app_slug,
                 token: res.token,
             })
         }
@@ -426,7 +434,7 @@ impl AccessTokenBuilder {
 struct RemoveAccessTokenRequest {
     endpoint: ApiEndpoint,
     token: String,
-    installation_id: u64,
+    installation_id: String,
     client: reqwest::Client,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,4 +677,39 @@ mod tests {
             })
         );
     }
+
+    #[wasm_bindgen_test]
+    fn deserializes_installation_metadata_response() {
+        let installation: InstallationResponse = serde_json::from_value(serde_json::json!({
+            "id": 123,
+            "app_slug": "octo-app"
+        }))
+        .unwrap();
+
+        assert_eq!(installation.id, 123);
+        assert_eq!(installation.app_slug, "octo-app");
+    }
+
+    #[wasm_bindgen_test]
+    fn output_state_round_trips_installation_metadata() {
+        let output = Output {
+            token: "ghs_token".to_string(),
+            installation_id: "123".to_string(),
+            app_slug: "octo-app".to_string(),
+        };
+        let value = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "token": "ghs_token",
+                "installation_id": "123",
+                "app_slug": "octo-app"
+            })
+        );
+
+        let round_trip: Output = serde_json::from_value(value).unwrap();
+        assert_eq!(round_trip.installation_id, "123");
+        assert_eq!(round_trip.app_slug, "octo-app");
+    }
 }


### PR DESCRIPTION
Adds installation-id and app-slug outputs alongside the generated token.