### PR TITLE
fix: harden token creation inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
       - id: gh-token-gen
         uses: oakcask/gh-token-gen@v4
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 ```
 
@@ -24,12 +24,13 @@ For GitHub Enterprise Server, set `github-api-url` explicitly:
       - id: gh-token-gen
         uses: oakcask/gh-token-gen@v4
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           github-api-url: https://github.example.com/api/v3
 ```
 
 The legacy `endpoint` input is still accepted as an alias for `github-api-url`.
+The legacy `app-id` input is still accepted as an alias for `client-id`.
 
 Set `owner` to create a token for every repository in that installation:
 
@@ -37,7 +38,7 @@ Set `owner` to create a token for every repository in that installation:
       - id: gh-token-gen
         uses: oakcask/gh-token-gen@v4
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 ```
@@ -48,7 +49,7 @@ Set `owner` and `repositories` to create a token scoped to selected repositories
       - id: gh-token-gen
         uses: oakcask/gh-token-gen@v4
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
@@ -65,7 +66,7 @@ Set `permission-<permission name>` inputs to limit the token permissions:
       - id: gh-token-gen
         uses: oakcask/gh-token-gen@v4
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/action.yaml
+++ b/action.yaml
@@ -3,8 +3,11 @@ name: gh-token-gen
 description: generate GitHub application token
 inputs:
   app-id:
-    required: true
+    default: ""
     description: GitHub Application ID (or Client ID)
+  client-id:
+    default: ""
+    description: GitHub App Client ID
   private-key:
     required: true
     description: "The application's PEM-encoded private key"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,8 @@ mod tests {
 
     fn input() -> Input {
         Input {
-            app_id: "client-id".to_string(),
+            app_id: "legacy-app-id".to_string(),
+            client_id: "client-id".to_string(),
             private_key: "private-key".to_string(),
             github_api_url: "https://api.github.com".to_string(),
             endpoint: String::new(),
@@ -640,6 +641,58 @@ mod tests {
     #[wasm_bindgen_test]
     fn rejects_github_api_url_without_authority() {
         assert!(ApiEndpoint::from_inputs("https:///api/v3", "").is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn client_id_prefers_new_input_over_deprecated_app_id() {
+        let mut input = input();
+        input.app_id = "legacy-app-id".to_string();
+        input.client_id = "client-id".to_string();
+
+        assert_eq!(input.client_id().unwrap(), "client-id");
+    }
+
+    #[wasm_bindgen_test]
+    fn client_id_falls_back_to_deprecated_app_id() {
+        let mut input = input();
+        input.app_id = "legacy-app-id".to_string();
+        input.client_id = " ".to_string();
+
+        assert_eq!(input.client_id().unwrap(), "legacy-app-id");
+    }
+
+    #[wasm_bindgen_test]
+    fn client_id_rejects_blank_aliases() {
+        let mut input = input();
+        input.app_id = " ".to_string();
+        input.client_id = String::new();
+
+        assert_eq!(
+            input.client_id().unwrap_err().to_string(),
+            "client-id or deprecated app-id must be set to a non-empty string"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn private_key_normalizes_escaped_newlines() {
+        let mut input = input();
+        input.private_key = "-----BEGIN KEY-----\\nabc\\n-----END KEY-----".to_string();
+
+        assert_eq!(
+            input.private_key().unwrap(),
+            "-----BEGIN KEY-----\nabc\n-----END KEY-----"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn private_key_rejects_blank_value() {
+        let mut input = input();
+        input.private_key = " ".to_string();
+
+        assert_eq!(
+            input.private_key().unwrap_err().to_string(),
+            "private-key must be set to a non-empty string"
+        );
     }
 
     #[wasm_bindgen_test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,13 @@ impl GhTokenGen {
 
 impl Action<Input, Output> for GhTokenGen {
     async fn main(input: Input) -> Result<Output, Error> {
+        let client_id = input.client_id()?;
+        let private_key = input.private_key()?;
         let endpoint = ApiEndpoint::from_inputs(&input.github_api_url, &input.endpoint)?;
         let target = InstallationTarget::resolve(&input)?;
         let authorization_header = JwtBuilder {
-            payload: Self::create_payload(input.app_id)?,
-            pkey: input.private_key,
+            payload: Self::create_payload(client_id)?,
+            pkey: private_key,
         }
         .build_authorization_header()
         .await?;
@@ -77,10 +79,12 @@ impl Action<Input, Output> for GhTokenGen {
 struct Input {
     #[input(
         name = "app-id",
-        required = true,
+        default = "",
         description = "GitHub Application ID (or Client ID)"
     )]
     app_id: String,
+    #[input(name = "client-id", default = "", description = "GitHub App Client ID")]
+    client_id: String,
     #[input(
         name = "private-key",
         required = true,
@@ -127,6 +131,32 @@ struct Input {
     repo: String,
     #[input(env = "GITHUB_REPOSITORY_OWNER")]
     repo_owner: String,
+}
+
+impl Input {
+    fn client_id(&self) -> Result<String, Error> {
+        let client_id = if self.client_id.trim().is_empty() {
+            self.app_id.trim()
+        } else {
+            self.client_id.trim()
+        };
+
+        if client_id.is_empty() {
+            Err(Error::from(
+                "client-id or deprecated app-id must be set to a non-empty string",
+            ))
+        } else {
+            Ok(client_id.to_string())
+        }
+    }
+
+    fn private_key(&self) -> Result<String, Error> {
+        if self.private_key.trim().is_empty() {
+            Err(Error::from("private-key must be set to a non-empty string"))
+        } else {
+            Ok(self.private_key.replace("\\n", "\n"))
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -225,6 +255,7 @@ struct AccessTokenBuilder {
     client: reqwest::Client,
 }
 
+#[derive(Clone)]
 enum InstallationTarget {
     Enterprise {
         enterprise: String,
@@ -406,6 +437,28 @@ impl AccessTokenBuilder {
     }
 
     async fn build(self) -> Result<AccessToken, Error> {
+        let mut last_error = None;
+
+        for attempt in 1..=4 {
+            match self.try_build().await {
+                Ok(access_token) => return Ok(access_token),
+                Err(e) => {
+                    if attempt == 4 {
+                        return Err(e);
+                    }
+                    warn!(
+                        "failed to create token, retrying attempt {}: {e}",
+                        attempt + 1
+                    );
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| Error::from("failed to create token")))
+    }
+
+    async fn try_build(&self) -> Result<AccessToken, Error> {
         let installation = self.get_installation().await?;
         let installation_id = installation.id;
         let path = format!("/app/installations/{}/access_tokens", installation_id);
@@ -413,7 +466,7 @@ impl AccessTokenBuilder {
 
         let body = AccessTokenRequest {
             repositories: self.target.repository_names(),
-            permissions: self.permissions,
+            permissions: self.permissions.clone(),
         };
         let res = self
             .client
@@ -421,7 +474,7 @@ impl AccessTokenBuilder {
             .header("Accept", "application/vnd.github+json")
             .header("User-Agent", USER_AGENT)
             .header("X-GitHub-Api-Version", "2022-11-28")
-            .header("Authorization", self.authorization_header)
+            .header("Authorization", self.authorization_header.clone())
             .json(&body)
             .send()
             .await


### PR DESCRIPTION
Adds client-id compatibility, validates empty inputs, normalizes escaped private-key newlines, and retries token creation.