### PR TITLE
feat: generate permission input metadata

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,6 +29,168 @@ inputs:
   skip-token-revoke:
     default: "false"
     description: "If true, the token will not be revoked when the current job is complete"
+  permission-actions:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-administration:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-artifact-metadata:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-attestations:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-checks:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-codespaces:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-contents:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-custom-properties-for-organizations:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-dependabot-secrets:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-deployments:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-discussions:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-email-addresses:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-enterprise-custom-properties-for-organizations:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-environments:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-followers:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-git-ssh-keys:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-gpg-keys:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-interaction-limits:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-issues:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-members:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-merge-queues:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-metadata:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-administration:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-announcement-banners:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-copilot-seat-management:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-custom-org-roles:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-custom-properties:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-custom-roles:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-events:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-hooks:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-packages:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-personal-access-token-requests:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-personal-access-tokens:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-plan:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-projects:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-secrets:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-self-hosted-runners:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-organization-user-blocking:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-packages:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-pages:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-profile:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-pull-requests:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-repository-custom-properties:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-repository-hooks:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-repository-projects:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-secret-scanning-alerts:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-secrets:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-security-events:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-single-file:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-starring:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-statuses:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-team-discussions:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-vulnerability-alerts:
+    default: ""
+    description: GitHub App permission level to grant to the access token
+  permission-workflows:
+    default: ""
+    description: GitHub App permission level to grant to the access token
 outputs:
   token:
     description: Generated token

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,82 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    wasm_actions_build::generate_recommended()
+    wasm_actions_build::generate_recommended()?;
+    add_permission_inputs()?;
+    Ok(())
+}
+
+fn add_permission_inputs() -> Result<(), Box<dyn std::error::Error>> {
+    const PERMISSIONS: &[&str] = &[
+        "actions",
+        "administration",
+        "artifact-metadata",
+        "attestations",
+        "checks",
+        "codespaces",
+        "contents",
+        "custom-properties-for-organizations",
+        "dependabot-secrets",
+        "deployments",
+        "discussions",
+        "email-addresses",
+        "enterprise-custom-properties-for-organizations",
+        "environments",
+        "followers",
+        "git-ssh-keys",
+        "gpg-keys",
+        "interaction-limits",
+        "issues",
+        "members",
+        "merge-queues",
+        "metadata",
+        "organization-administration",
+        "organization-announcement-banners",
+        "organization-copilot-seat-management",
+        "organization-custom-org-roles",
+        "organization-custom-properties",
+        "organization-custom-roles",
+        "organization-events",
+        "organization-hooks",
+        "organization-packages",
+        "organization-personal-access-token-requests",
+        "organization-personal-access-tokens",
+        "organization-plan",
+        "organization-projects",
+        "organization-secrets",
+        "organization-self-hosted-runners",
+        "organization-user-blocking",
+        "packages",
+        "pages",
+        "profile",
+        "pull-requests",
+        "repository-custom-properties",
+        "repository-hooks",
+        "repository-projects",
+        "secret-scanning-alerts",
+        "secrets",
+        "security-events",
+        "single-file",
+        "starring",
+        "statuses",
+        "team-discussions",
+        "vulnerability-alerts",
+        "workflows",
+    ];
+
+    let mut action = std::fs::read_to_string("action.yaml")?;
+    if action.contains("  permission-actions:") {
+        return Ok(());
+    }
+
+    let permission_inputs = PERMISSIONS
+        .iter()
+        .map(|permission| {
+            format!(
+                "  permission-{permission}:\n    default: \"\"\n    description: GitHub App permission level to grant to the access token\n"
+            )
+        })
+        .collect::<String>();
+    action = action.replace("\noutputs:\n", &format!("\n{permission_inputs}outputs:\n"));
+    std::fs::write("action.yaml", action)?;
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,4 +883,32 @@ mod tests {
             "Bearer ghs_token"
         );
     }
+
+    #[wasm_bindgen_test]
+    fn action_metadata_includes_generated_permission_inputs() {
+        let action = include_str!("../action.yaml");
+
+        for permission in [
+            "permission-actions",
+            "permission-contents",
+            "permission-pull-requests",
+            "permission-vulnerability-alerts",
+            "permission-workflows",
+        ] {
+            assert!(action.contains(&format!("  {permission}:")));
+        }
+        assert!(action
+            .contains("description: GitHub App permission level to grant to the access token"));
+    }
+
+    #[wasm_bindgen_test]
+    fn action_metadata_keeps_declared_outputs_after_permission_inputs() {
+        let action = include_str!("../action.yaml");
+        let permissions = action.find("  permission-actions:").unwrap();
+        let outputs = action.find("outputs:").unwrap();
+
+        assert!(permissions < outputs);
+        assert!(action.contains("  installation-id:"));
+        assert!(action.contains("  app-slug:"));
+    }
 }


### PR DESCRIPTION
Adds generated permission-* metadata entries to action.yaml so supported permissions are visible to the Actions runner and editor tooling.