### PR TITLE
fix(deps): upgrade tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,9 +1535,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
resolve blocker of https://github.com/oakcask/gh-token-gen/pull/396